### PR TITLE
Extend DB schema with categories and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,33 @@ CREATE TABLE polres (
   website TEXT NOT NULL
 );
 
+CREATE TABLE categories (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE tags (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE
+);
+
 CREATE TABLE articles (
   id SERIAL PRIMARY KEY,
   title TEXT NOT NULL,
   link TEXT NOT NULL,
   content TEXT,
   published_at TIMESTAMP,
-  polres_id INTEGER REFERENCES polres(id)
+  polres_id INTEGER REFERENCES polres(id),
+  category_id INTEGER REFERENCES categories(id),
+  author TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE article_tags (
+  article_id INTEGER REFERENCES articles(id) ON DELETE CASCADE,
+  tag_id INTEGER REFERENCES tags(id) ON DELETE CASCADE,
+  PRIMARY KEY (article_id, tag_id)
 );
 ```
 
@@ -61,5 +81,9 @@ Modul `src/scraper/scraper.js` memuat mekanisme scraping menggunakan `axios` dan
 - `GET /polres` – daftar Polres
 - `POST /polres` – tambah Polres baru (`name`, `website`)
 - `GET /polres/:polresId/articles` – daftar artikel milik Polres
+- `GET /categories` – daftar kategori
+- `POST /categories` – tambah kategori baru (`name`)
+- `GET /tags` – daftar tag
+- `POST /tags` – tambah tag baru (`name`)
 
 Frontend dapat menggunakan API ini sebagai dasar pengelolaan data pemberitaan.

--- a/server.js
+++ b/server.js
@@ -2,6 +2,8 @@ const express = require('express');
 const cron = require('node-cron');
 const polresRoutes = require('./src/routes/polres');
 const articlesRoutes = require('./src/routes/articles');
+const categoriesRoutes = require('./src/routes/categories');
+const tagsRoutes = require('./src/routes/tags');
 const scraper = require('./src/scraper/scraper');
 require('dotenv').config();
 
@@ -10,6 +12,8 @@ app.use(express.json());
 
 app.use('/polres', polresRoutes);
 app.use('/polres/:polresId/articles', articlesRoutes);
+app.use('/categories', categoriesRoutes);
+app.use('/tags', tagsRoutes);
 
 // schedule scraping every hour
 cron.schedule('0 * * * *', async () => {

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -4,11 +4,31 @@ CREATE TABLE IF NOT EXISTS polres (
   website TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS categories (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS tags (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE
+);
+
 CREATE TABLE IF NOT EXISTS articles (
   id SERIAL PRIMARY KEY,
   title TEXT NOT NULL,
   link TEXT NOT NULL,
   content TEXT,
   published_at TIMESTAMP,
-  polres_id INTEGER REFERENCES polres(id)
+  polres_id INTEGER REFERENCES polres(id),
+  category_id INTEGER REFERENCES categories(id),
+  author TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS article_tags (
+  article_id INTEGER REFERENCES articles(id) ON DELETE CASCADE,
+  tag_id INTEGER REFERENCES tags(id) ON DELETE CASCADE,
+  PRIMARY KEY (article_id, tag_id)
 );

--- a/sql/seed.sql
+++ b/sql/seed.sql
@@ -1,3 +1,13 @@
 INSERT INTO polres (name, website) VALUES
 ('Polres Surabaya', 'https://www.polrestabesurabaya.net'),
 ('Polres Malang', 'https://www.polresmalangnews.com');
+
+INSERT INTO categories (name) VALUES
+('Umum'),
+('Kriminal'),
+('Humas');
+
+INSERT INTO tags (name) VALUES
+('Breaking'),
+('Internal'),
+('PressRelease');

--- a/src/models/article.js
+++ b/src/models/article.js
@@ -1,11 +1,19 @@
 const db = require('../db');
 
 async function create(data) {
-  const { title, link, content, published_at, polres_id } = data;
+  const {
+    title,
+    link,
+    content,
+    published_at,
+    polres_id,
+    category_id,
+    author,
+  } = data;
   const { rows } = await db.query(
-    `INSERT INTO articles (title, link, content, published_at, polres_id)
-     VALUES ($1, $2, $3, $4, $5) RETURNING *`,
-    [title, link, content, published_at, polres_id]
+    `INSERT INTO articles (title, link, content, published_at, polres_id, category_id, author)
+     VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *`,
+    [title, link, content, published_at, polres_id, category_id, author]
   );
   return rows[0];
 }

--- a/src/models/category.js
+++ b/src/models/category.js
@@ -1,0 +1,16 @@
+const db = require('../db');
+
+async function getAll() {
+  const { rows } = await db.query('SELECT * FROM categories ORDER BY id');
+  return rows;
+}
+
+async function create(name) {
+  const { rows } = await db.query(
+    'INSERT INTO categories (name) VALUES ($1) RETURNING *',
+    [name]
+  );
+  return rows[0];
+}
+
+module.exports = { getAll, create };

--- a/src/models/tag.js
+++ b/src/models/tag.js
@@ -1,0 +1,16 @@
+const db = require('../db');
+
+async function getAll() {
+  const { rows } = await db.query('SELECT * FROM tags ORDER BY id');
+  return rows;
+}
+
+async function create(name) {
+  const { rows } = await db.query(
+    'INSERT INTO tags (name) VALUES ($1) RETURNING *',
+    [name]
+  );
+  return rows[0];
+}
+
+module.exports = { getAll, create };

--- a/src/routes/categories.js
+++ b/src/routes/categories.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const categoryModel = require('../models/category');
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  try {
+    const data = await categoryModel.getAll();
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'internal' });
+  }
+});
+
+router.post('/', async (req, res) => {
+  const { name } = req.body;
+  try {
+    const category = await categoryModel.create(name);
+    res.json(category);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'internal' });
+  }
+});
+
+module.exports = router;

--- a/src/routes/tags.js
+++ b/src/routes/tags.js
@@ -1,0 +1,27 @@
+const express = require('express');
+const tagModel = require('../models/tag');
+
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  try {
+    const data = await tagModel.getAll();
+    res.json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'internal' });
+  }
+});
+
+router.post('/', async (req, res) => {
+  const { name } = req.body;
+  try {
+    const tag = await tagModel.create(name);
+    res.json(tag);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'internal' });
+  }
+});
+
+module.exports = router;

--- a/src/scraper/scraper.js
+++ b/src/scraper/scraper.js
@@ -33,7 +33,9 @@ async function scrape(polres) {
       await articleModel.create({
         ...art,
         published_at: new Date(),
-        polres_id: polres.id
+        polres_id: polres.id,
+        category_id: null,
+        author: null
       });
     }
   } catch (err) {


### PR DESCRIPTION
## Summary
- expand schema to include categories, tags, article_tags and additional article fields
- seed default categories and tags
- add models and routes for categories and tags
- update scraper and article model to handle new columns
- document new tables and routes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e5e9e59908327ab58153d538b8dd5