### PR TITLE
Add extended article fields and improved scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # News Management Backend
 
-Backend sederhana berbasis Node.js untuk manajemen data dan pemberitaan jajaran Polda Jatim. Backend ini menyediakan API dasar untuk menyimpan data Polres, melakukan scraping berita dari website rekanan, serta menyimpan hasilnya pada database PostgreSQL.
+Backend sederhana berbasis Node.js untuk manajemen data dan pemberitaan jajaran Polda Jatim. Backend ini menyediakan API dasar untuk menyimpan data Polres, melakukan scraping berita dari website rekanan, serta menyimpan hasilnya pada database PostgreSQL. Versi ini menambahkan beberapa kolom pada tabel `articles` agar informasi seperti ringkasan berita, gambar utama, serta sumber media dapat tersimpan dengan lebih lengkap.
 
 ## Konfigurasi
 
@@ -55,10 +55,16 @@ CREATE TABLE articles (
   title TEXT NOT NULL,
   link TEXT NOT NULL,
   content TEXT,
+  summary TEXT,
+  image_url TEXT,
   published_at TIMESTAMP,
   polres_id INTEGER REFERENCES polres(id),
   category_id INTEGER REFERENCES categories(id),
   author TEXT,
+  source TEXT,
+  comment_count INTEGER,
+  share_count INTEGER,
+  view_count INTEGER,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -75,6 +81,7 @@ Tambahkan data Polres awal dengan API `POST /polres` atau langsung pada database
 ## Scraping
 
 Modul `src/scraper/scraper.js` memuat mekanisme scraping menggunakan `axios` dan `cheerio`. Selector bawaan bersifat generik sehingga mungkin perlu disesuaikan dengan struktur website berita masing-masing Polres agar hasil lebih optimal.
+Selain judul dan tautan, scraper juga mencoba mengambil tanggal publikasi, ringkasan singkat, serta gambar utama apabila tersedia. Nilai lain seperti jumlah komentar atau share dapat diisi bila situs sumber menampilkannya.
 
 ## Rute API Singkat
 

--- a/sql/init.sql
+++ b/sql/init.sql
@@ -19,10 +19,16 @@ CREATE TABLE IF NOT EXISTS articles (
   title TEXT NOT NULL,
   link TEXT NOT NULL,
   content TEXT,
+  summary TEXT,
+  image_url TEXT,
   published_at TIMESTAMP,
   polres_id INTEGER REFERENCES polres(id),
   category_id INTEGER REFERENCES categories(id),
   author TEXT,
+  source TEXT,
+  comment_count INTEGER,
+  share_count INTEGER,
+  view_count INTEGER,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );

--- a/src/models/article.js
+++ b/src/models/article.js
@@ -5,15 +5,21 @@ async function create(data) {
     title,
     link,
     content,
+    summary,
+    image_url,
     published_at,
     polres_id,
     category_id,
     author,
+    source,
+    comment_count,
+    share_count,
+    view_count,
   } = data;
   const { rows } = await db.query(
-    `INSERT INTO articles (title, link, content, published_at, polres_id, category_id, author)
-     VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING *`,
-    [title, link, content, published_at, polres_id, category_id, author]
+    `INSERT INTO articles (title, link, content, summary, image_url, published_at, polres_id, category_id, author, source, comment_count, share_count, view_count)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) RETURNING *`,
+    [title, link, content, summary, image_url, published_at, polres_id, category_id, author, source, comment_count, share_count, view_count]
   );
   return rows[0];
 }

--- a/src/scraper/scraper.js
+++ b/src/scraper/scraper.js
@@ -8,7 +8,10 @@ const defaultSelectors = {
   article: 'article',
   title: 'h1,h2',
   link: 'a',
-  content: 'p'
+  content: 'p',
+  date: 'time',
+  snippet: 'p',
+  thumbnail: 'img'
 };
 
 function extractArticles($, selectors = defaultSelectors, baseUrl) {
@@ -19,7 +22,11 @@ function extractArticles($, selectors = defaultSelectors, baseUrl) {
     if (!title || !link) return;
     const absoluteLink = link.startsWith('http') ? link : new URL(link, baseUrl).href;
     const content = $(el).find(selectors.content).text().trim();
-    articles.push({ title, link: absoluteLink, content });
+    const snippet = $(el).find(selectors.snippet).first().text().trim();
+    const dateText = $(el).find(selectors.date).first().attr('datetime') || $(el).find(selectors.date).first().text();
+    const image = $(el).find(selectors.thumbnail).first().attr('src');
+    const published_at = dateText ? new Date(dateText) : new Date();
+    articles.push({ title, link: absoluteLink, content, summary: snippet, image_url: image, published_at });
   });
   return articles;
 }
@@ -32,10 +39,13 @@ async function scrape(polres) {
     for (const art of articles) {
       await articleModel.create({
         ...art,
-        published_at: new Date(),
         polres_id: polres.id,
         category_id: null,
-        author: null
+        author: null,
+        source: polres.name,
+        comment_count: null,
+        share_count: null,
+        view_count: null
       });
     }
   } catch (err) {


### PR DESCRIPTION
## Summary
- expand articles table to store summary, image, source and engagement info
- update article model to handle new fields
- scrape extra information such as publish date, snippet and thumbnail
- document new columns and scraper behaviour in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_686e6a32727c832783ed6999980cd379